### PR TITLE
Fix m7(b5) parsing and optimize MIDI chord analysis

### DIFF
--- a/CompingApp/cifrado_utils.py
+++ b/CompingApp/cifrado_utils.py
@@ -35,16 +35,27 @@ def analizar_cifrado(cifrado):
         sufijo = sufijo.strip()
         extensiones = []
 
-        # Extraer extensiones en paréntesis
-        sufijo_base = sufijo
-        if '(' in sufijo:
-            parentesis = re.findall(r'\((.*?)\)', sufijo)
+        # Detectar la base del acorde antes de procesar extensiones
+        base, resto = alias_a_clave_acordes(sufijo)
+        if not base or base not in acordes:
+            if sufijo == '' or sufijo.startswith('7'):
+                base = '7'
+                resto = sufijo[1:] if sufijo.startswith('7') else ''
+            else:
+                print(f"¡Acorde no reconocido: {sufijo}! Usando 7 por defecto.")
+                base = '7'
+                resto = sufijo
+
+        # Extraer extensiones en paréntesis del resto
+        sufijo_base = resto
+        if '(' in sufijo_base:
+            parentesis = re.findall(r'\((.*?)\)', sufijo_base)
             for contenido in parentesis:
                 for ext in contenido.split(','):
                     ext = ext.strip()
                     if ext:
                         extensiones.append(ext)
-            sufijo_base = re.sub(r'\(.*?\)', '', sufijo).strip()
+            sufijo_base = re.sub(r'\(.*?\)', '', sufijo_base).strip()
 
         # Extraer extensiones pegadas fuera de paréntesis
         for ext_tag in ['b9', '#9', '9', '#11', '11', 'b13', '13']:
@@ -53,13 +64,9 @@ def analizar_cifrado(cifrado):
                 sufijo_base = sufijo_base.replace(ext_tag, '')
 
         sufijo_base = sufijo_base.strip()
-        base, resto_limpio = alias_a_clave_acordes(sufijo_base)
-        if not base or base not in acordes:
-            if sufijo_base == '':
-                base = '7'
-            else:
-                print(f"¡Acorde no reconocido: {sufijo_base}! Usando 7 por defecto.")
-                base = "7"
+        if sufijo_base:
+            print(f"¡Acorde no reconocido: {sufijo_base}! Usando 7 por defecto.")
+
         grados_base = acordes[base][:]
 
         e_9 = next((e for e in extensiones if '9' in e), None)

--- a/CompingApp/procesa_midi.py
+++ b/CompingApp/procesa_midi.py
@@ -49,7 +49,12 @@ def procesa_midi(reference_midi_path="reference_comping.mid", cifrado="", corche
     tiempo_fin = tiempo_inicio + total_corcheas * dur_corchea
 
     acordes_corchea = expandir_cifrado_a_corcheas(cifrado, total_corcheas, corcheas_por_compas)
-    acordes_analizados = [analizar_cifrado(a)[0] for a in acordes_corchea]
+    cache = {}
+    acordes_analizados = []
+    for a in acordes_corchea:
+        if a not in cache:
+            cache[a] = analizar_cifrado(a)[0]
+        acordes_analizados.append(cache[a])
 
     for i in range(total_corcheas):
         t0 = tiempo_inicio + i * dur_corchea

--- a/CompingApp/test_parser.py
+++ b/CompingApp/test_parser.py
@@ -1,43 +1,8 @@
-import re
+from cifrado_utils import analizar_cifrado
 
-acordes = {
-    "m7(b5)": [0,3,6,10],
-    "7": [0,4,7,10],
-    "m7": [0,3,7,10],
-    "∆": [0,4,7,11],
-}
 
-def alias_a_clave_acordes(resto):
-    semidim_pat = r'^(m7\(b5\)|m7b5|min7b5|mi7b5|\-7b5|ø7|ø)'
-    if re.match(semidim_pat, resto, re.IGNORECASE):
-        return "m7(b5)", re.sub(semidim_pat, '', resto, flags=re.IGNORECASE)
-    menor_pat = r'^(min|mi|m|\-)'
-    if re.match(menor_pat, resto, re.IGNORECASE):
-        return "m7", re.sub(menor_pat, '', resto, flags=re.IGNORECASE)
-    mayor_pat = r'^(maj|major|Maj|M|∆)'
-    if re.match(mayor_pat, resto, re.IGNORECASE):
-        return "∆", re.sub(mayor_pat, '', resto, flags=re.IGNORECASE)
-    return None, resto
-
-def analizar_cifrado(cifrado):
-    resultado = []
-    tokens = cifrado.split()
-    for token in tokens:
-        m = re.match(r'^([A-G][#b]?)(.*)$', token)
-        if not m:
-            print(f"NO MATCH: {token}")
-            continue
-        fundamental, resto = m.groups()
-        resto = resto.strip()
-        base, resto2 = alias_a_clave_acordes(resto)
-        print(f"TOKEN: '{token}' | Base: '{base}' | resto2: '{resto2}'")
-        if not base:
-            base = "7"
-        grados = acordes[base]
-        print(f"--> Grados: {grados}")
-        resultado.append((fundamental, grados))
-    return resultado
-
-# TESTEA ESTO:
-cifrado = "Bø Bø7 Bm7(b5) Bmin7b5 B-7b5 Bmi7b5"
-analizar_cifrado(cifrado)
+def test_m7b5_aliases():
+    aliases = ["Bø", "Bø7", "Bm7(b5)", "Bmin7b5", "B-7b5", "Bmi7b5"]
+    esperado = ("B", [0, 3, 6, 10])
+    for cif in aliases:
+        assert analizar_cifrado(cif) == [esperado]


### PR DESCRIPTION
## Summary
- Handle m7(b5) chord quality before extension parsing to avoid misclassification
- Cache chord analysis in MIDI processing to avoid repeated parsing
- Add regression tests for m7(b5) aliases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d198dd0b48333b76daacc84d2594d