### PR TITLE
Fix 6(9) chord parsing and MIDI translation

### DIFF
--- a/CompingApp/cifrado_utils.py
+++ b/CompingApp/cifrado_utils.py
@@ -3,24 +3,22 @@ from acordes_dict import acordes
 
 def alias_a_clave_acordes(resto):
     suf = resto.replace(" ", "").replace('[', '(').replace(']', ')').lower()
-    for pat in ["m7(b5)", "m7b5", "min7b5", "mi7b5", "-7b5", "ø7", "ø"]:
-        if suf.startswith(pat):
-            return "m7(b5)", resto[len(pat):]
-    for pat in ["min", "mi", "m", "-"]:
-        if suf.startswith(pat):
-            return "m", resto[len(pat):]
-    for pat in ["maj", "major", "maj", "m", "∆"]:
-        if suf.startswith(pat):
-            return "∆", resto[len(pat):]
-    for pat in ["dim", "º", "o"]:
-        if suf.startswith(pat):
-            return "º", resto[len(pat):]
-    for pat in ["aug", "+"]:
-        if suf.startswith(pat):
-            return "+", resto[len(pat):]
-    for pat in ["sus4", "sus"]:
-        if suf.startswith(pat):
-            return "sus", resto[len(pat):]
+
+    alias_patterns = [
+        ("m7(b5)", ["m7(b5)", "m7b5", "min7b5", "mi7b5", "-7b5", "ø7", "ø"]),
+        ("m6", ["m6"]),
+        ("6", ["6"]),
+        ("m", ["min", "mi", "m", "-"]),
+        ("∆", ["maj", "major", "maj", "m", "∆"]),
+        ("º", ["dim", "º", "o"]),
+        ("+", ["aug", "+"]),
+        ("sus", ["sus4", "sus"]),
+    ]
+
+    for base, pats in alias_patterns:
+        for pat in pats:
+            if suf.startswith(pat):
+                return base, resto[len(pat):]
     return None, resto
 
 def analizar_cifrado(cifrado):

--- a/CompingApp/procesa_midi.py
+++ b/CompingApp/procesa_midi.py
@@ -1,4 +1,3 @@
-import pretty_midi
 import os
 from acordes_dict import acordes
 from cifrado_utils import analizar_cifrado
@@ -39,6 +38,7 @@ def notas_midi_acorde(fundamental, grados, base_octava=4):
     return [base + intervalo for intervalo in grados]
 
 def procesa_midi(reference_midi_path="reference_comping.mid", cifrado="", corcheas_por_compas=8, dur_corchea=0.25):
+    import pretty_midi
     midi = pretty_midi.PrettyMIDI(reference_midi_path)
     pista = midi.instruments[0]
     notas = pista.notes

--- a/CompingApp/test_parser.py
+++ b/CompingApp/test_parser.py
@@ -1,4 +1,5 @@
 from cifrado_utils import analizar_cifrado
+from procesa_midi import notas_midi_acorde
 
 
 def test_m7b5_aliases():
@@ -6,3 +7,10 @@ def test_m7b5_aliases():
     esperado = ("B", [0, 3, 6, 10])
     for cif in aliases:
         assert analizar_cifrado(cif) == [esperado]
+
+
+def test_6_9_parsing_and_midi():
+    cifrado = "C6(9)"
+    esperado = ("C", [2, 4, 7, 9])
+    assert analizar_cifrado(cifrado) == [esperado]
+    assert notas_midi_acorde(*esperado) == [50, 52, 55, 57]


### PR DESCRIPTION
## Summary
- support '6' and 'm6' chord bases and aliases for correct 6(9) analysis
- defer heavy `pretty_midi` import inside MIDI processing for lighter module usage
- add regression test ensuring C6(9) parses and maps to expected MIDI notes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d1f4bc4248333ae634754db001037