### PR TITLE
Implementa enlace de notas minimizando movimiento entre acordes

### DIFF
--- a/CompingApp/test_parser.py
+++ b/CompingApp/test_parser.py
@@ -1,5 +1,5 @@
 from cifrado_utils import analizar_cifrado
-from procesa_midi import notas_midi_acorde
+from procesa_midi import notas_midi_acorde, enlazar_notas
 
 
 def test_m7b5_aliases():
@@ -14,3 +14,9 @@ def test_6_9_parsing_and_midi():
     esperado = ("C", [2, 4, 7, 9])
     assert analizar_cifrado(cifrado) == [esperado]
     assert notas_midi_acorde(*esperado) == [50, 52, 55, 57]
+
+
+def test_enlazar_notas_minimo_movimiento():
+    previas = [72, 60, 64, 67]
+    nuevas = [60, 64, 67, 71]
+    assert enlazar_notas(previas, nuevas) == [71, 60, 64, 67]


### PR DESCRIPTION
## Resumen
- Se añade la función `enlazar_notas` para asignar notas del nuevo acorde a las anteriores minimizando el movimiento de cada voz.
- `procesa_midi` ahora utiliza `enlazar_notas` para mantener el enlace de voces entre acordes.
- Se agrega prueba unitaria que verifica el enlace de notas con mínimo movimiento.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d24488b588333b3e8ed37f0ce30d0