### PR TITLE
Ensure four-note chords and add inversion selection

### DIFF
--- a/CompingApp/comping_ui.py
+++ b/CompingApp/comping_ui.py
@@ -1,5 +1,5 @@
 import tkinter as tk
-from tkinter import messagebox
+from tkinter import messagebox, ttk
 import os
 from procesa_midi import procesa_midi
 
@@ -17,6 +17,13 @@ class MidiApp(tk.Tk):
         self.midi_label = tk.Label(self, text="Archivo MIDI de referencia: reference_comping.mid")
         self.midi_label.pack(pady=10)
 
+        self.inv_label = tk.Label(self, text="Inversión inicial del acorde:")
+        self.inv_label.pack()
+        self.inversion = ttk.Combobox(self, state="readonly")
+        self.inversion['values'] = ("fundamental", "primera inversión", "segunda inversión", "tercera inversión")
+        self.inversion.current(0)
+        self.inversion.pack(pady=5)
+
         self.export_btn = tk.Button(self, text="Exportar MIDI", command=self.export_midi)
         self.export_btn.pack(pady=20)
 
@@ -29,7 +36,8 @@ class MidiApp(tk.Tk):
             messagebox.showerror("Error", "No se encontró 'reference_comping.mid' en esta carpeta.")
             return
         try:
-            out_path = procesa_midi("reference_comping.mid", cifrado)
+            inversion_idx = self.inversion.current()
+            out_path = procesa_midi("reference_comping.mid", cifrado, inversion_inicial=inversion_idx)
             messagebox.showinfo("¡Listo!", f"Archivo exportado:\n{out_path}")
         except Exception as e:
             messagebox.showerror("Error", f"Ocurrió un error:\n{e}")

--- a/CompingApp/test_parser.py
+++ b/CompingApp/test_parser.py
@@ -25,6 +25,6 @@ def test_enlazar_notas_minimo_movimiento():
 def test_inversion_limita_salto_de_bajo():
     primero = notas_midi_acorde("C", [0, 4, 7])
     segundo = notas_midi_acorde("B", [0, 4, 7], prev_bajo=primero[0])
-    assert primero == [60, 64, 67]
+    assert primero == [60, 64, 67, 79]
     assert abs(segundo[0] - primero[0]) <= 5
-    assert segundo == [59, 63, 66]
+    assert segundo == [59, 63, 66, 78]


### PR DESCRIPTION
## Summary
- guarantee four-note chord generation when reference MIDI has notes
- allow choosing inversion of the first chord in the GUI
- adjust tests for four-note chord output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d34f38a888333a4659501ba3a21ae