### PR TITLE
Ensure chord inversions keep four notes in close position

### DIFF
--- a/CompingApp/procesa_midi.py
+++ b/CompingApp/procesa_midi.py
@@ -39,12 +39,21 @@ def notas_midi_acorde(fundamental, grados, base_octava=4, prev_bajo=None, invers
     ``inversion`` (0=fundamental, 1=1ª inversión, ...).  Para los acordes
     siguientes se elige automáticamente la inversión y el desplazamiento de
     octava cuya nota más grave quede lo más cercana posible a ``prev_bajo``.
-    El resultado siempre contiene cuatro notas, duplicando la más aguda si el
-    acorde original tiene menos voces.
+    El resultado siempre contiene cuatro notas en posición cerrada, duplicando
+    la fundamental a la octava superior si el acorde original tiene menos
+    voces.
     """
     if fundamental not in notas_naturales:
         fundamental = 'C'
     base = 12 * base_octava + notas_naturales[fundamental]
+
+    # Asegurar que siempre trabajamos con cuatro grados.  Si el acorde es una
+    # tríada se duplica la fundamental a la octava.
+    grados = list(grados)
+    if len(grados) < 4:
+        grados = grados + [grados[0] + 12]
+    else:
+        grados = grados[:4]
 
     mejor_inversion = None
     mejor_dist = None
@@ -93,8 +102,12 @@ def notas_midi_acorde(fundamental, grados, base_octava=4, prev_bajo=None, invers
                 bajo = mejor_inversion[0]
 
     if mejor_inversion:
-        while len(mejor_inversion) < 4:
-            mejor_inversion.append(mejor_inversion[-1] + 12)
+        if len(mejor_inversion) < 4:
+            mejor_inversion += [mejor_inversion[0] + 12] * (4 - len(mejor_inversion))
+        while max(mejor_inversion) - min(mejor_inversion) > 12:
+            max_idx = mejor_inversion.index(max(mejor_inversion))
+            mejor_inversion[max_idx] -= 12
+            mejor_inversion.sort()
 
     return mejor_inversion
 

--- a/CompingApp/test_parser.py
+++ b/CompingApp/test_parser.py
@@ -25,6 +25,6 @@ def test_enlazar_notas_minimo_movimiento():
 def test_inversion_limita_salto_de_bajo():
     primero = notas_midi_acorde("C", [0, 4, 7])
     segundo = notas_midi_acorde("B", [0, 4, 7], prev_bajo=primero[0])
-    assert primero == [60, 64, 67, 79]
+    assert primero == [60, 64, 67, 72]
     assert abs(segundo[0] - primero[0]) <= 5
-    assert segundo == [59, 63, 66, 78]
+    assert segundo == [59, 63, 66, 71]


### PR DESCRIPTION
## Summary
- enforce four-note close voicings in `notas_midi_acorde`, respecting selected inversion
- adjust test expectations to reflect new close-position inversions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d3e1132188333b535fbdaf407986b