### PR TITLE
Garantizar acordes de cuatro notas

### DIFF
--- a/CompingApp/cifrado_utils.py
+++ b/CompingApp/cifrado_utils.py
@@ -35,6 +35,14 @@ def analizar_cifrado(cifrado):
 
         # Detectar la base del acorde antes de procesar extensiones
         base, resto = alias_a_clave_acordes(sufijo)
+        if base == 'm':
+            base = 'm7'
+        elif base == '+':
+            base = '+7'
+        elif base == 'º':
+            base = 'º7'
+        elif base == 'sus':
+            base = '7sus4'
         if not base or base not in acordes:
             if sufijo == '' or sufijo.startswith('7'):
                 base = '7'
@@ -77,19 +85,16 @@ def analizar_cifrado(cifrado):
             "13": 9, "b13": 8
         }
 
-        grados_final = grados_base[:]
-        if e_11 and e_13:
-            grados_final[0] = ext_map.get(e_9 or "9", 2)
-            grados_final[1] = ext_map.get(e_11, 5)
-            grados_final[2] = ext_map.get(e_13, 9)
-        elif e_13:
-            grados_final[0] = ext_map.get(e_9 or "9", 2)
-            grados_final[2] = ext_map.get(e_13, 9)
-        elif e_11:
-            grados_final[0] = ext_map.get(e_9 or "9", 2)
-            grados_final[2] = ext_map.get(e_11, 5)
-        elif e_9:
-            grados_final[0] = ext_map.get(e_9, 2)
+        if e_13 or e_11 or e_9:
+            grados_final = [grados_base[0], grados_base[1], grados_base[3]]
+            if e_13:
+                grados_final.append(ext_map.get(e_13, 9))
+            elif e_11:
+                grados_final.append(ext_map.get(e_11, 5))
+            else:
+                grados_final.append(ext_map.get(e_9, 2))
+        else:
+            grados_final = grados_base[:]
 
         resultado.append((fundamental, grados_final))
     return resultado

--- a/CompingApp/procesa_midi.py
+++ b/CompingApp/procesa_midi.py
@@ -39,21 +39,16 @@ def notas_midi_acorde(fundamental, grados, base_octava=4, prev_bajo=None, invers
     ``inversion`` (0=fundamental, 1=1ª inversión, ...).  Para los acordes
     siguientes se elige automáticamente la inversión y el desplazamiento de
     octava cuya nota más grave quede lo más cercana posible a ``prev_bajo``.
-    El resultado siempre contiene cuatro notas en posición cerrada, duplicando
-    la fundamental a la octava superior si el acorde original tiene menos
-    voces.
+    El resultado siempre contiene cuatro notas en posición cerrada. ``grados``
+    debe describir exactamente cuatro alturas distintas del acorde.
     """
     if fundamental not in notas_naturales:
         fundamental = 'C'
     base = 12 * base_octava + notas_naturales[fundamental]
 
-    # Asegurar que siempre trabajamos con cuatro grados.  Si el acorde es una
-    # tríada se duplica la fundamental a la octava.
     grados = list(grados)
-    if len(grados) < 4:
-        grados = grados + [grados[0] + 12]
-    else:
-        grados = grados[:4]
+    if len(grados) != 4:
+        raise ValueError("Se requieren cuatro grados para construir el acorde")
 
     mejor_inversion = None
     mejor_dist = None
@@ -102,8 +97,7 @@ def notas_midi_acorde(fundamental, grados, base_octava=4, prev_bajo=None, invers
                 bajo = mejor_inversion[0]
 
     if mejor_inversion:
-        if len(mejor_inversion) < 4:
-            mejor_inversion += [mejor_inversion[0] + 12] * (4 - len(mejor_inversion))
+        mejor_inversion.sort()
         while max(mejor_inversion) - min(mejor_inversion) > 12:
             max_idx = mejor_inversion.index(max(mejor_inversion))
             mejor_inversion[max_idx] -= 12

--- a/CompingApp/test_parser.py
+++ b/CompingApp/test_parser.py
@@ -11,9 +11,9 @@ def test_m7b5_aliases():
 
 def test_6_9_parsing_and_midi():
     cifrado = "C6(9)"
-    esperado = ("C", [2, 4, 7, 9])
+    esperado = ("C", [0, 4, 9, 2])
     assert analizar_cifrado(cifrado) == [esperado]
-    assert notas_midi_acorde(*esperado) == [50, 52, 55, 57]
+    assert notas_midi_acorde(*esperado) == [60, 62, 64, 69]
 
 
 def test_enlazar_notas_minimo_movimiento():
@@ -23,8 +23,8 @@ def test_enlazar_notas_minimo_movimiento():
 
 
 def test_inversion_limita_salto_de_bajo():
-    primero = notas_midi_acorde("C", [0, 4, 7])
-    segundo = notas_midi_acorde("B", [0, 4, 7], prev_bajo=primero[0])
-    assert primero == [60, 64, 67, 72]
+    primero = notas_midi_acorde("C", [0, 4, 7, 10])
+    segundo = notas_midi_acorde("B", [0, 4, 7, 10], prev_bajo=primero[0])
+    assert primero == [60, 64, 67, 70]
     assert abs(segundo[0] - primero[0]) <= 5
-    assert segundo == [59, 63, 66, 71]
+    assert segundo == [59, 63, 66, 69]


### PR DESCRIPTION
## Summary
- Map triad aliases to four-note chord symbols and retain the root when applying extensions
- Require `notas_midi_acorde` to receive exactly four degrees and return sorted four-note voicings
- Update unit tests for new four-note behavior

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d4233496483338e336ffba8b3154c