### PR TITLE
Control de rango y enlace de acordes

### DIFF
--- a/CompingApp/test_parser.py
+++ b/CompingApp/test_parser.py
@@ -28,3 +28,16 @@ def test_inversion_limita_salto_de_bajo():
     assert primero == [60, 64, 67, 70]
     assert abs(segundo[0] - primero[0]) <= 5
     assert segundo == [59, 63, 66, 69]
+
+
+def test_rango_de_voces():
+    """La voz superior no debe superar C5 y la inferior no debe bajar de D3."""
+    primero = notas_midi_acorde("C", [0, 4, 7, 11])
+    assert primero[0] >= 50
+    assert max(primero) <= 72
+
+    # Forzar un bajo previo alto para comprobar el límite superior
+    segundo = notas_midi_acorde("F", [0, 4, 7, 11], prev_bajo=65)
+    assert abs(segundo[0] - 65) <= 5
+    assert segundo[0] >= 50
+    assert max(segundo) <= 72


### PR DESCRIPTION
## Resumen
- Se mejoró `notas_midi_acorde` para elegir inversiones que mantengan las voces entre D3 y C5 y eviten saltos de bajo mayores a 5 semitonos.
- Se ajustó la lógica de registro para no exceder el límite superior de C5 y se documentó la nueva restricción de rango.
- Se añadieron pruebas que validan el mantenimiento del rango y la coherencia del enlace entre acordes.

## Pruebas
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d45df4b6c833396a620e15e15347b