### PR TITLE
Fix MIDI export loop

### DIFF
--- a/CompingApp/procesa_midi.py
+++ b/CompingApp/procesa_midi.py
@@ -95,7 +95,17 @@ def notas_midi_acorde(fundamental, grados, base_octava=4, prev_bajo=None, invers
     # Ajustar para que el bajo no salte más de cinco semitonos
     if mejor_inversion and prev_bajo is not None:
         bajo = mejor_inversion[0]
+        visitados = set()
+        # En algunos casos no es posible reducir la distancia a cinco
+        # semitonos únicamente desplazando por octavas.  El bucle original
+        # intentaba hacerlo indefinidamente, provocando un bucle infinito
+        # cuando la diferencia se alternaba entre dos valores (por ejemplo
+        # 6 y -6).  Para evitarlo, registramos las alturas visitadas y
+        # abandonamos si no se logra mejorar.
         while abs(bajo - prev_bajo) > 5:
+            if bajo in visitados:
+                break
+            visitados.add(bajo)
             if bajo < prev_bajo:
                 mejor_inversion = [n + 12 for n in mejor_inversion]
             else:
@@ -128,7 +138,11 @@ def notas_midi_acorde(fundamental, grados, base_octava=4, prev_bajo=None, invers
         # salto del bajo no exceda cinco semitonos.
         if prev_bajo is not None:
             bajo = mejor_inversion[0]
+            visitados = set()
             while abs(bajo - prev_bajo) > 5:
+                if bajo in visitados:
+                    break
+                visitados.add(bajo)
                 if bajo < prev_bajo:
                     mejor_inversion = [n + 12 for n in mejor_inversion]
                 else:

--- a/CompingApp/test_notas_midi_acorde.py
+++ b/CompingApp/test_notas_midi_acorde.py
@@ -1,0 +1,19 @@
+import signal
+import pytest
+from procesa_midi import notas_midi_acorde
+
+
+def test_notas_midi_acorde_no_infinite_loop():
+    # Configurar alarma para evitar bucles infinitos
+    def handler(signum, frame):
+        raise TimeoutError("timeout")
+    signal.signal(signal.SIGALRM, handler)
+    signal.alarm(1)
+    try:
+        # Este acorde artificial (todas las notas a una distancia de seis
+        # semitonos del bajo previo) provocaba un bucle infinito en la versión
+        # anterior.
+        notas = notas_midi_acorde('C', [6, 18, 30, 42], base_octava=4, prev_bajo=60)
+    finally:
+        signal.alarm(0)
+    assert len(notas) == 4


### PR DESCRIPTION
## Summary
- Avoid infinite loop when adjusting chord bass notes by tracking visited pitches
- Add regression test to ensure `notas_midi_acorde` returns even when chords are six semitones apart

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d49b5c004833397eed0fc2365954d