### PR TITLE
Respeta extensiones reemplazando notas

### DIFF
--- a/CompingApp/cifrado_utils.py
+++ b/CompingApp/cifrado_utils.py
@@ -48,9 +48,14 @@ def analizar_cifrado(cifrado):
                 base = '7'
                 resto = sufijo[1:] if sufijo.startswith('7') else ''
             else:
-                print(f"¡Acorde no reconocido: {sufijo}! Usando 7 por defecto.")
                 base = '7'
                 resto = sufijo
+                conocidos = ['b9', '#9', '9', '#11', '11', 'b13', '13']
+                if not any(tag in sufijo for tag in conocidos):
+                    print(f"¡Acorde no reconocido: {sufijo}! Usando 7 por defecto.")
+
+        if resto.startswith('7'):
+            resto = resto[1:]
 
         # Extraer extensiones en paréntesis del resto
         sufijo_base = resto
@@ -85,16 +90,15 @@ def analizar_cifrado(cifrado):
             "13": 9, "b13": 8
         }
 
-        if e_13 or e_11 or e_9:
-            grados_final = [grados_base[0], grados_base[1], grados_base[3]]
-            if e_13:
-                grados_final.append(ext_map.get(e_13, 9))
-            elif e_11:
-                grados_final.append(ext_map.get(e_11, 5))
-            else:
-                grados_final.append(ext_map.get(e_9, 2))
-        else:
-            grados_final = grados_base[:]
+        grados_final = grados_base[:]
+        if e_13:
+            grados_final[2] = ext_map.get(e_13, 9)
+            grados_final[0] = ext_map.get(e_9, 2)
+        elif e_11:
+            grados_final[1] = ext_map.get(e_11, 5)
+            grados_final[0] = ext_map.get(e_9, 2)
+        elif e_9:
+            grados_final[0] = ext_map.get(e_9, 2)
 
         resultado.append((fundamental, grados_final))
     return resultado

--- a/CompingApp/test_parser.py
+++ b/CompingApp/test_parser.py
@@ -11,9 +11,25 @@ def test_m7b5_aliases():
 
 def test_6_9_parsing_and_midi():
     cifrado = "C6(9)"
-    esperado = ("C", [0, 4, 9, 2])
+    esperado = ("C", [2, 4, 7, 9])
     assert analizar_cifrado(cifrado) == [esperado]
-    assert notas_midi_acorde(*esperado) == [60, 62, 64, 69]
+    assert notas_midi_acorde(*esperado) == [50, 52, 55, 57]
+
+
+def test_extensiones_reemplazan_notas():
+    nombres = {0: 'C', 1: 'Db', 2: 'D', 3: 'Eb', 4: 'E', 5: 'F', 6: 'Gb', 7: 'G', 8: 'Ab', 9: 'A', 10: 'Bb', 11: 'B'}
+    cifrados = ["Dm7(9)", "G13", "C∆(9)", "C6(9)"]
+    esperados = [
+        ['E', 'F', 'A', 'C'],
+        ['A', 'B', 'E', 'F'],
+        ['D', 'E', 'G', 'B'],
+        ['D', 'E', 'G', 'A'],
+    ]
+    for cif, notas_esp in zip(cifrados, esperados):
+        fund, grados = analizar_cifrado(cif)[0]
+        midi = notas_midi_acorde(fund, grados)
+        notas = [nombres[n % 12] for n in midi]
+        assert sorted(notas) == sorted(notas_esp)
 
 
 def test_enlazar_notas_minimo_movimiento():


### PR DESCRIPTION
## Summary
- Reemplaza notas estructurales por extensiones en la interpretación del cifrado (p.ej. la 9ª sustituye a la fundamental)
- Actualiza y añade pruebas para acordes con extensiones como Dm7(9), G13, C∆(9) y C6(9)

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d4d3b11b883338a69ab68eb55359e