### PR TITLE
Evita solapamiento de notas y ajusta exportación

### DIFF
--- a/CompingApp/comping_ui.py
+++ b/CompingApp/comping_ui.py
@@ -50,7 +50,7 @@ class MidiApp(tk.Tk):
             return
         try:
             out_path = procesa_midi("reference_comping.mid", cifrado, rotacion=self.rotacion)
-            messagebox.showinfo("¡Listo!", f"Archivo exportado:\n{out_path}")
+            print(f"Archivo exportado: {out_path}")
         except Exception as e:
             messagebox.showerror("Error", f"Ocurrió un error:\n{e}")
 

--- a/CompingApp/test_solapamiento.py
+++ b/CompingApp/test_solapamiento.py
@@ -1,0 +1,22 @@
+import types
+from procesa_midi import evitar_solapamientos
+
+class DummyNote:
+    def __init__(self, start, end, pitch):
+        self.start = start
+        self.end = end
+        self.pitch = pitch
+
+def test_evitar_solapamientos():
+    n1 = DummyNote(0.0, 1.0, 60)
+    n2 = DummyNote(0.9, 1.5, 60)
+    notas = [n1, n2]
+    evitar_solapamientos(notas)
+    assert n1.end <= n2.start and n1.end >= n1.start
+
+def test_no_cambio_sin_solapamiento():
+    n1 = DummyNote(0.0, 0.5, 60)
+    n2 = DummyNote(0.6, 1.0, 60)
+    notas = [n1, n2]
+    evitar_solapamientos(notas)
+    assert n1.end == 0.5


### PR DESCRIPTION
## Summary
- Reduce la duración de notas consecutivas con la misma altura para evitar artefactos MIDI.
- Exporta los archivos MIDI a `Desktop/output` numerándolos de forma incremental y eliminando el mensaje emergente de éxito.
- Añade pruebas unitarias para verificar el ajuste de solapamientos.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d5a11fe848333811b24b642178a83