### PR TITLE
Add MIDI preview and selectable output port

### DIFF
--- a/CompingApp/comping_ui.py
+++ b/CompingApp/comping_ui.py
@@ -1,7 +1,12 @@
 import tkinter as tk
-from tkinter import messagebox
+from tkinter import messagebox, ttk
 import os
 from procesa_midi import procesa_midi
+
+try:
+    import mido
+except Exception:  # pragma: no cover - mido no es esencial para las pruebas
+    mido = None
 
 class MidiApp(tk.Tk):
     def __init__(self):
@@ -27,8 +32,17 @@ class MidiApp(tk.Tk):
         self.rot_plus = tk.Button(self.rot_frame, text="+", command=self.rotar_mas)
         self.rot_plus.pack(side="left")
 
+        self.port_label = tk.Label(self, text="Puerto MIDI de salida:")
+        self.port_label.pack(pady=5)
+        self.port_combo = ttk.Combobox(self, state="readonly")
+        self.port_combo.pack()
+        self.refresh_ports()
+
+        self.preview_btn = tk.Button(self, text="Previsualizar", command=self.preview_midi)
+        self.preview_btn.pack(pady=10)
+
         self.export_btn = tk.Button(self, text="Exportar MIDI", command=self.export_midi)
-        self.export_btn.pack(pady=20)
+        self.export_btn.pack(pady=5)
 
     def rotar_mas(self):
         if self.rotacion < 3:
@@ -39,6 +53,51 @@ class MidiApp(tk.Tk):
         if self.rotacion > -3:
             self.rotacion -= 1
             self.rot_label.config(text=f"Rotar: {self.rotacion:+d}")
+
+    def get_midi_ports(self):
+        if mido is None:
+            return []
+        try:
+            return mido.get_output_names()
+        except Exception:
+            return []
+
+    def refresh_ports(self):
+        ports = self.get_midi_ports()
+        self.port_combo["values"] = ports
+        if ports:
+            self.port_combo.current(0)
+
+    def preview_midi(self):
+        if mido is None:
+            messagebox.showerror("Error", "La librería mido no está instalada.")
+            return
+        cifrado = self.cifrado_entry.get("1.0", tk.END).strip()
+        if not cifrado:
+            messagebox.showerror("Error", "Por favor, escribe un cifrado.")
+            return
+        if not os.path.exists("reference_comping.mid"):
+            messagebox.showerror("Error", "No se encontró 'reference_comping.mid' en esta carpeta.")
+            return
+        port_name = self.port_combo.get()
+        if not port_name:
+            messagebox.showerror("Error", "Selecciona un puerto MIDI.")
+            return
+        try:
+            midi_obj = procesa_midi(
+                "reference_comping.mid", cifrado, rotacion=self.rotacion, save=False
+            )
+            import io
+
+            midi_bytes = io.BytesIO()
+            midi_obj.write(midi_bytes)
+            midi_bytes.seek(0)
+            mid = mido.MidiFile(file=midi_bytes)
+            with mido.open_output(port_name) as port:
+                for msg in mid.play():
+                    port.send(msg)
+        except Exception as e:
+            messagebox.showerror("Error", f"Ocurrió un error al previsualizar:\n{e}")
 
     def export_midi(self):
         cifrado = self.cifrado_entry.get("1.0", tk.END).strip()

--- a/CompingApp/procesa_midi.py
+++ b/CompingApp/procesa_midi.py
@@ -203,9 +203,25 @@ def evitar_solapamientos(notas, margen=0.01):
                 nuevo_fin = actual.start
             actual.end = nuevo_fin
 
-def procesa_midi(reference_midi_path="reference_comping.mid", cifrado="", corcheas_por_compas=8, dur_corchea=0.25, rotacion=0):
+def procesa_midi(
+    reference_midi_path="reference_comping.mid",
+    cifrado="",
+    corcheas_por_compas=8,
+    dur_corchea=0.25,
+    rotacion=0,
+    save=True,
+):
+    """Genera un archivo MIDI con el cifrado indicado.
+
+    Si ``save`` es ``True`` (valor por defecto) el resultado se escribe en un
+    archivo dentro de ``~/Desktop/output`` y se devuelve la ruta al mismo.  Si
+    ``save`` es ``False`` se devuelve el objeto ``PrettyMIDI`` resultante sin
+    persistirlo en disco, lo cual permite previsualizar el MIDI antes de
+    exportarlo definitivamente.
+    """
     import pretty_midi
     from collections import defaultdict
+
     midi = pretty_midi.PrettyMIDI(reference_midi_path)
     pista = midi.instruments[0]
     notas = pista.notes
@@ -289,14 +305,17 @@ def procesa_midi(reference_midi_path="reference_comping.mid", cifrado="", corche
 
     pista.notes = notas_finales
 
-    out_dir = Path.home() / "Desktop" / "output"
-    out_dir.mkdir(parents=True, exist_ok=True)
-    indices = [int(p.stem) for p in out_dir.glob("*.mid") if p.stem.isdigit()]
-    next_idx = max(indices, default=0) + 1
-    out_path = out_dir / f"{next_idx}.mid"
-    midi.write(str(out_path))
-    print(f"Archivo exportado: {out_path}")
-    archivos = sorted(out_dir.glob("*.mid"), key=lambda p: int(p.stem))
-    for p in archivos:
-        print(p.name)
-    return str(out_path)
+    if save:
+        out_dir = Path.home() / "Desktop" / "output"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        indices = [int(p.stem) for p in out_dir.glob("*.mid") if p.stem.isdigit()]
+        next_idx = max(indices, default=0) + 1
+        out_path = out_dir / f"{next_idx}.mid"
+        midi.write(str(out_path))
+        print(f"Archivo exportado: {out_path}")
+        archivos = sorted(out_dir.glob("*.mid"), key=lambda p: int(p.stem))
+        for p in archivos:
+            print(p.name)
+        return str(out_path)
+    else:
+        return midi


### PR DESCRIPTION
## Summary
- allow selecting MIDI output ports from a combobox
- add preview button to play generated MIDI through selected port
- support skipping file export in `procesa_midi` for previewing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d5c89d0508333bba083825eccc52c