### PR TITLE
Permitir rotar acordes individuales

### DIFF
--- a/CompingApp/test_rotaciones.py
+++ b/CompingApp/test_rotaciones.py
@@ -1,0 +1,35 @@
+from procesa_midi import aplicar_rotaciones
+
+class Note:
+    def __init__(self, pitch, start):
+        self.pitch = pitch
+        self.start = start
+
+
+def group_pitches(notes):
+    groups = {}
+    for n in notes:
+        groups.setdefault(n.start, []).append(n.pitch)
+    return {k: sorted(v) for k, v in sorted(groups.items())}
+
+
+def test_rotacion_global():
+    notas = [
+        Note(60, 0), Note(64, 0), Note(67, 0), Note(72, 0),
+        Note(61, 1), Note(65, 1), Note(68, 1), Note(73, 1),
+    ]
+    aplicar_rotaciones(notas, rotacion=1)
+    grupos = group_pitches(notas)
+    assert grupos[0] == [64, 67, 72, 72]
+    assert grupos[1] == [65, 68, 73, 73]
+
+
+def test_rotacion_por_acorde():
+    notas = [
+        Note(60, 0), Note(64, 0), Note(67, 0), Note(72, 0),
+        Note(61, 1), Note(65, 1), Note(68, 1), Note(73, 1),
+    ]
+    aplicar_rotaciones(notas, rotaciones={1: 1})
+    grupos = group_pitches(notas)
+    assert grupos[0] == [60, 64, 67, 72]
+    assert grupos[1] == [65, 68, 73, 73]


### PR DESCRIPTION
## Resumen
- Permite rotar acordes seleccionados desde la UI, conservando rotación global cuando no hay selección.
- Añade `aplicar_rotaciones` para manejar rotaciones globales o por acorde en el procesamiento MIDI.
- Incluye pruebas unitarias para asegurar el correcto comportamiento de las rotaciones.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d5f06abb0833391a6d22f908ee5d1