### PR TITLE
Corrige reemplazo de quinta por onceava en acordes extendidos

### DIFF
--- a/CompingApp/cifrado_utils.py
+++ b/CompingApp/cifrado_utils.py
@@ -95,7 +95,7 @@ def analizar_cifrado(cifrado):
             grados_final[2] = ext_map.get(e_13, 9)
             grados_final[0] = ext_map.get(e_9, 2)
         elif e_11:
-            grados_final[1] = ext_map.get(e_11, 5)
+            grados_final[2] = ext_map.get(e_11, 5)
             grados_final[0] = ext_map.get(e_9, 2)
         elif e_9:
             grados_final[0] = ext_map.get(e_9, 2)

--- a/CompingApp/test_parser.py
+++ b/CompingApp/test_parser.py
@@ -32,6 +32,20 @@ def test_extensiones_reemplazan_notas():
         assert sorted(notas) == sorted(notas_esp)
 
 
+def test_extensiones_combinadas_generan_notas_correctas():
+    casos = [
+        ("A7(b9)#11", {10: 'Bb', 1: 'C#', 3: 'D#', 7: 'G'}),
+        ("D7(#9)b13", {5: 'E#', 6: 'F#', 10: 'Bb', 0: 'C'}),
+        ("Dm7(b5)9", {4: 'E', 5: 'F', 8: 'Ab', 0: 'C'}),
+        ("Ebm7(11)", {5: 'F', 6: 'Gb', 8: 'Ab', 1: 'Db'}),
+    ]
+    for cif, mapa in casos:
+        fund, grados = analizar_cifrado(cif)[0]
+        midi = notas_midi_acorde(fund, grados)
+        notas = [mapa[n % 12] for n in midi]
+        assert sorted(notas) == sorted(mapa.values())
+
+
 def test_enlazar_notas_minimo_movimiento():
     previas = [72, 60, 64, 67]
     nuevas = [60, 64, 67, 71]


### PR DESCRIPTION
## Summary
- Corrige la lógica de `analizar_cifrado` para que las onceavas reemplacen la quinta del acorde
- Añade pruebas para acordes con combinaciones de b9, #11, b13 y 11 que verifican las notas resultantes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d66dd3a2c8333aef43479b854e5d7