### PR TITLE
Evitar legato al recortar notas

### DIFF
--- a/CompingApp/procesa_midi.py
+++ b/CompingApp/procesa_midi.py
@@ -205,6 +205,23 @@ def evitar_solapamientos(notas, margen=0.01):
             actual.end = nuevo_fin
 
 
+def recortar_notas_a_segmento(notas, inicio, fin):
+    """Recorta notas para que se mantengan dentro del segmento ``[inicio, fin]``.
+
+    Solo se acortan las notas; nunca se extienden. Si el inicio queda por
+    encima del final tras el recorte, se ajusta el final para que coincida con
+    el inicio.
+    """
+    for n in notas:
+        if n.start < inicio:
+            n.start = inicio
+        if n.end > fin:
+            n.end = fin
+        if n.end < n.start:
+            n.end = n.start
+    return notas
+
+
 def aplicar_rotaciones(notas, rotacion=0, rotaciones=None):
     """Aplica rotaciones de inversión a listas de notas.
 
@@ -294,6 +311,9 @@ def procesa_midi(
                                          end=t1)
                 notas.append(nueva)
                 notas_corchea.append(nueva)
+
+        # Evitar legato forzando las notas a encajar en los límites del segmento
+        recortar_notas_a_segmento(notas_corchea, t0, t1)
 
         fundamental, grados = acordes_analizados[i]
         if i == 0:

--- a/CompingApp/test_recortar_notas.py
+++ b/CompingApp/test_recortar_notas.py
@@ -1,0 +1,28 @@
+from procesa_midi import recortar_notas_a_segmento
+
+class DummyNote:
+    def __init__(self, start, end, pitch=60):
+        self.start = start
+        self.end = end
+        self.pitch = pitch
+
+
+def test_recorta_nota_larga():
+    n = DummyNote(0.0, 0.5)
+    recortar_notas_a_segmento([n], 0.0, 0.25)
+    assert n.start == 0.0
+    assert n.end == 0.25
+
+
+def test_no_alarga_nota_corta():
+    n = DummyNote(0.05, 0.20)
+    recortar_notas_a_segmento([n], 0.0, 0.25)
+    assert n.start == 0.05
+    assert n.end == 0.20
+
+
+def test_recorta_inicio_fuera_segmento():
+    n = DummyNote(-0.1, 0.2)
+    recortar_notas_a_segmento([n], 0.0, 0.25)
+    assert n.start == 0.0
+    assert n.end == 0.2


### PR DESCRIPTION
## Summary
- Recorta notas para que no salgan del segmento de corchea y evita legato
- Añade pruebas unitarias sobre el recorte de notas

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d6aba7248833385edf6e4724f459e