### PR TITLE
Agregar función Spread

### DIFF
--- a/CompingApp/comping_ui.py
+++ b/CompingApp/comping_ui.py
@@ -37,6 +37,10 @@ class MidiApp(tk.Tk):
         self.reset_btn = tk.Button(self, text="Reestablecer", command=self.reset_rotaciones)
         self.reset_btn.pack(pady=5)
 
+        self.spread_var = tk.BooleanVar(value=False)
+        self.spread_btn = tk.Checkbutton(self, text="Spread", variable=self.spread_var)
+        self.spread_btn.pack(pady=5)
+
         self.port_label = tk.Label(self, text="Puerto MIDI de salida:")
         self.port_label.pack(pady=5)
         self.port_combo = ttk.Combobox(self, state="readonly")
@@ -141,6 +145,7 @@ class MidiApp(tk.Tk):
                 cifrado,
                 rotacion=self.rotacion,
                 rotaciones=self.rotaciones_forzadas,
+                spread=self.spread_var.get(),
                 save=False,
             )
             import io
@@ -169,6 +174,7 @@ class MidiApp(tk.Tk):
                 cifrado,
                 rotacion=self.rotacion,
                 rotaciones=self.rotaciones_forzadas,
+                spread=self.spread_var.get(),
             )
             print(f"Archivo exportado: {out_path}")
         except Exception as e:

--- a/CompingApp/test_spread.py
+++ b/CompingApp/test_spread.py
@@ -1,0 +1,24 @@
+from procesa_midi import Spread
+
+
+class Note:
+    def __init__(self, pitch, start=0.0, end=1.0, velocity=100):
+        self.pitch = pitch
+        self.start = start
+        self.end = end
+        self.velocity = velocity
+
+
+def test_spread_duplica_segunda_nota():
+    notas = [Note(p) for p in (60, 64, 67, 71)]
+    Spread(notas)
+    pitches = sorted(n.pitch for n in notas)
+    assert len(notas) == 6
+    assert pitches.count(64) == 1
+    assert 76 in pitches and 88 in pitches
+    segunda = [n for n in notas if n.pitch == 64][0]
+    for p in (76, 88):
+        dup = [n for n in notas if n.pitch == p][0]
+        assert dup.start == segunda.start
+        assert dup.end == segunda.end
+        assert dup.velocity == segunda.velocity


### PR DESCRIPTION
## Summary
- Add Spread utility to duplicate the second note of each chord at +12 and +24 semitones
- Integrate Spread toggle into the UI and processing pipeline
- Cover Spread behaviour with new unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d6dfb5b2c8333b933ebdc96f90f26