### PR TITLE
Enhance Spread voicing with intermediate chord tone

### DIFF
--- a/CompingApp/procesa_midi.py
+++ b/CompingApp/procesa_midi.py
@@ -254,7 +254,12 @@ def aplicar_rotaciones(notas, rotacion=0, rotaciones=None):
 
 
 def Spread(notas):
-    """Duplica la segunda nota de cada acorde una y dos octavas arriba."""
+    """Duplica notas del acorde para crear un voicing abierto.
+
+    Se duplica la segunda nota del acorde una y dos octavas arriba y se
+    agrega una de las notas del acorde una octava arriba, ubicada entre las
+    dos notas duplicadas anteriores.
+    """
 
     grupos = defaultdict(list)
     for n in notas:
@@ -264,14 +269,23 @@ def Spread(notas):
     for grupo in grupos.values():
         if len(grupo) < 2:
             continue
-        segunda = sorted(grupo, key=lambda n: n.pitch)[1]
+        ordenado = sorted(grupo, key=lambda n: n.pitch)
+        segunda = ordenado[1]
+        # Selecciona la nota más aguda del acorde para el agregado intermedio.
+        extra = ordenado[-1]
+
         cls = segunda.__class__
-        for desplazamiento in (12, 24):
+        duplicados = (
+            (segunda, 12),
+            (extra, 12),
+            (segunda, 24),
+        )
+        for nota, desplazamiento in duplicados:
             nueva = cls(
-                velocity=getattr(segunda, "velocity", 0),
-                pitch=segunda.pitch + desplazamiento,
-                start=segunda.start,
-                end=segunda.end,
+                velocity=getattr(nota, "velocity", 0),
+                pitch=nota.pitch + desplazamiento,
+                start=nota.start,
+                end=nota.end,
             )
             nuevas.append(nueva)
     notas.extend(nuevas)

--- a/CompingApp/test_spread.py
+++ b/CompingApp/test_spread.py
@@ -9,16 +9,25 @@ class Note:
         self.velocity = velocity
 
 
-def test_spread_duplica_segunda_nota():
+def test_spread_agrega_nota_intermedia():
     notas = [Note(p) for p in (60, 64, 67, 71)]
     Spread(notas)
     pitches = sorted(n.pitch for n in notas)
-    assert len(notas) == 6
+    # Se agregan tres notas nuevas
+    assert len(notas) == 7
     assert pitches.count(64) == 1
-    assert 76 in pitches and 88 in pitches
+    # Notas duplicadas: E+12, B+12 y E+24
+    assert {76, 83, 88}.issubset(set(pitches))
+
     segunda = [n for n in notas if n.pitch == 64][0]
     for p in (76, 88):
         dup = [n for n in notas if n.pitch == p][0]
         assert dup.start == segunda.start
         assert dup.end == segunda.end
         assert dup.velocity == segunda.velocity
+
+    alto = [n for n in notas if n.pitch == 71][0]
+    intermedia = [n for n in notas if n.pitch == 83][0]
+    assert intermedia.start == alto.start
+    assert intermedia.end == alto.end
+    assert intermedia.velocity == alto.velocity


### PR DESCRIPTION
## Summary
- extend `Spread` to insert an extra chord tone one octave up between the existing duplicated notes
- adjust unit test for new Spread behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d7127af84833380d712dff17fbaa7